### PR TITLE
Formatting of Files

### DIFF
--- a/src/charts.rs
+++ b/src/charts.rs
@@ -117,7 +117,8 @@ impl<'a> Chart<'a> {
     for n in 1..13 {
       let label = match timeframe {
         Timeframe::Daily => {
-          let date = (now + chrono::Duration::minutes(offset.into())) - chrono::Duration::days(12 - n);
+          let date =
+            (now + chrono::Duration::minutes(offset.into())) - chrono::Duration::days(12 - n);
           date.format("%m/%d").to_string()
         }
         Timeframe::Weekly => {

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -609,7 +609,10 @@ pub async fn add(
       {
         error!("Leaderboard: Error generating images: {:?}", err);
       }
-      log::info!("Leaderboard: Generation completed in {:#?}", generation_start.elapsed());
+      log::info!(
+        "Leaderboard: Generation completed in {:#?}",
+        generation_start.elapsed()
+      );
     });
     update_leaderboards.await?;
   }

--- a/src/commands/challenge.rs
+++ b/src/commands/challenge.rs
@@ -310,7 +310,11 @@ pub async fn stats(
           .with_minute(0)
           .unwrap_or_default();
         let days = (end_time - start_time).num_days();
-        if days == 0 { 1 } else { days }
+        if days == 0 {
+          1
+        } else {
+          days
+        }
       };
 
       let total_time = stats.timeframe_stats.sum.unwrap_or(0) as f64;
@@ -462,7 +466,11 @@ pub async fn stats(
         .with_minute(0)
         .unwrap_or_default();
       let days = (end_time - start_time).num_days();
-      if days == 0 { 1 } else { days }
+      if days == 0 {
+        1
+      } else {
+        days
+      }
     };
 
     let total_time = stats.timeframe_stats.sum.unwrap_or(0) as f64;

--- a/src/commands/coffee.rs
+++ b/src/commands/coffee.rs
@@ -4,9 +4,9 @@ use rand::Rng;
 use std::sync::Arc;
 
 /// Are you feeling lucky?
-/// 
+///
 /// Are you feeling lucky?
-/// 
+///
 /// I will choose either ☕ or ⚰️.
 #[poise::command(slash_command, category = "Utilities")]
 pub async fn coffee(ctx: Context<'_>) -> Result<()> {

--- a/src/commands/hello.rs
+++ b/src/commands/hello.rs
@@ -2,9 +2,9 @@ use crate::Context;
 use anyhow::Result;
 
 /// Say hello to Bloom!
-/// 
+///
 /// Say hello to Bloom.
-/// 
+///
 /// Don't worry - Bloom is friendly :)
 #[poise::command(slash_command, category = "Utilities")]
 pub async fn hello(ctx: Context<'_>) -> Result<()> {

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -193,7 +193,8 @@ async fn help_all_commands<U, E>(
     });
 
   if config.show_context_menu_commands {
-    let mut context_categories = indexmap::IndexMap::<Option<&str>, Vec<&poise::Command<U, E>>>::new();
+    let mut context_categories =
+      indexmap::IndexMap::<Option<&str>, Vec<&poise::Command<U, E>>>::new();
     for cmd in &ctx.framework().options().commands {
       if cmd.context_menu_action.is_none() || cmd.hide_in_help {
         continue;

--- a/src/commands/recent.rs
+++ b/src/commands/recent.rs
@@ -81,7 +81,8 @@ pub async fn recent(
       .create_response(
         ctx,
         CreateInteractionResponse::UpdateMessage(
-          CreateInteractionResponseMessage::new().embed(pagination.create_page_embed(current_page, PageType::Standard)),
+          CreateInteractionResponseMessage::new()
+            .embed(pagination.create_page_embed(current_page, PageType::Standard)),
         ),
       )
       .await?;

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -225,9 +225,14 @@ pub async fn user(
     None => false,
   };
 
-  let chart_stats =
-    DatabaseHandler::get_user_chart_stats(&mut transaction, &guild_id, &user.id, &timeframe, tracking_profile.utc_offset)
-      .await?;
+  let chart_stats = DatabaseHandler::get_user_chart_stats(
+    &mut transaction,
+    &guild_id,
+    &user.id,
+    &timeframe,
+    tracking_profile.utc_offset,
+  )
+  .await?;
 
   let chart = charts::Chart::new()
     .await?

--- a/src/commands/suggest.rs
+++ b/src/commands/suggest.rs
@@ -71,7 +71,9 @@ pub async fn suggest(
   ctx
     .send(
       poise::CreateReply::default()
-        .content(format!("Your suggestion has been added to <#{channel_id}>."))
+        .content(format!(
+          "Your suggestion has been added to <#{channel_id}>."
+        ))
         .ephemeral(true),
     )
     .await?;

--- a/src/commands/uptime.rs
+++ b/src/commands/uptime.rs
@@ -18,7 +18,9 @@ pub async fn uptime(ctx: Context<'_>) -> Result<()> {
   let (days, hours) = div_mod(hours, 24);
 
   ctx
-    .say(format!("My current uptime is {days}d {hours}h {minutes}m {seconds}s."))
+    .say(format!(
+      "My current uptime is {days}d {hours}h {minutes}m {seconds}s."
+    ))
     .await?;
 
   Ok(())

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -6,10 +6,10 @@ use poise::serenity_prelude::{builder::*, ChannelId, Context, MessageFlags, Reac
 // mod guild_member_addition;
 mod guild_member_removal;
 mod guild_member_update;
+pub mod leaderboards;
 mod message_delete;
 mod reaction_add;
 mod reaction_remove;
-pub mod leaderboards;
 
 // pub use guild_member_addition::guild_member_addition;
 pub use guild_member_removal::guild_member_removal;
@@ -54,10 +54,12 @@ pub async fn create_star_message(
     };
 
     let mut embed = match starred_message.embeds.first() {
-      Some(embed) => if starred_message.content.is_empty() {
-        config::BloomBotEmbed::from(embed.clone())
-      } else {
-        config::BloomBotEmbed::new().description(starred_message.content.clone())
+      Some(embed) => {
+        if starred_message.content.is_empty() {
+          config::BloomBotEmbed::from(embed.clone())
+        } else {
+          config::BloomBotEmbed::new().description(starred_message.content.clone())
+        }
       }
       None => config::BloomBotEmbed::new().description(starred_message.content.clone()),
     };

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -140,11 +140,7 @@ impl PaginationPage<'_> {
     self.entries.is_empty()
   }
 
-  pub fn to_embed(
-    &self,
-    title: &str,
-    page_type: PageType,
-  ) -> serenity::CreateEmbed {
+  pub fn to_embed(&self, title: &str, page_type: PageType) -> serenity::CreateEmbed {
     let mut embed = BloomBotEmbed::new().title(title).description(format!(
       "Showing entries {} to {}.",
       (self.page_number * self.entries_per_page) + 1,


### PR DESCRIPTION
Rust has a built in formatter that you can run on all files with `cargo fmt --all`, which is all this PR includes. This ensures that the syntax, indentation, and order of `use` statements is optimized to best practices.

On PR #2 I included a GitHub Actions workflow that will automatically check the formatting for every PR to ensure that the formatting has been done to standard.