### PR TITLE
Traits for creation/update/deletion; implementation for Bookmark

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     services:
       postgres:
-        image: pgvector/pgvector:1.7
+        image: pgvector/pgvector:pg17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Rust toolchain installation
-        run: rustup toolchain install stable --profile minimal --no-self-update
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          cargo install sqlx-cli --no-default-features --features postgres
+          cargo sqlx database create
+          cargo sqlx migrate run
       - name: Caching setup
         uses: Swatinem/rust-cache@v2
       - name: Checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,22 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  DISCORD_TOKEN: ''
+  TEST_GUILD_ID: ''
+  DATABASE_URL: postgres://postgres:password@postgres/bloom
+  OPENAI_API_KEY: ''
 
 jobs:
   test:
+    services:
+      postgres:
+        image: pgvector/pgvector:1.7
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
   DISCORD_TOKEN: ''
   TEST_GUILD_ID: ''
-  DATABASE_URL: postgres://postgres:password@postgres/bloom
+  DATABASE_URL: postgres://postgres:password@localhost:5432/bloom
   OPENAI_API_KEY: ''
 
 jobs:

--- a/.sqlx/query-f60b59c7d4b54e43ab6d21a8f04bb6bac018c9cf4a3213d59c4a7d480779973a.json
+++ b/.sqlx/query-f60b59c7d4b54e43ab6d21a8f04bb6bac018c9cf4a3213d59c4a7d480779973a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n          DELETE FROM bookmarks WHERE record_id = $1\n        ",
+  "query": "\n        DELETE FROM bookmarks WHERE record_id = $1\n      ",
   "describe": {
     "columns": [],
     "parameters": {
@@ -10,5 +10,5 @@
     },
     "nullable": []
   },
-  "hash": "b14b9245bbbda27706758cfc2ea5c11840d7944cb88d002177fcf3f0f0b85ac6"
+  "hash": "f60b59c7d4b54e43ab6d21a8f04bb6bac018c9cf4a3213d59c4a7d480779973a"
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ is built in Rust using the [Poise](https://docs.rs/poise/0.6.1/poise/index.html)
 
 1. Install Rust
 2. Clone the repository
-3. Run PostgreSQL: `docker run --name bloom-db -e POSTGRES_PASSWORD=supersecret -p 5432:5432 -d postgres` (choose any password you would like)
+3. Run PostgreSQL: `docker run --name bloom-db -e POSTGRES_PASSWORD=supersecret -p 5432:5432 -d pgvector/pgvector:1.7` (choose any password you would like)
 4. Copy the `.env.example` file to `.env` and fill in the necessary values. Be sure to set the password in the DATABASE_URL to the one you chose in step 3.
 5. Run `cargo run` to start the bot
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ is built in Rust using the [Poise](https://docs.rs/poise/0.6.1/poise/index.html)
 
 1. Install Rust
 2. Clone the repository
-3. Run PostgreSQL: `docker run --name bloom-db -e POSTGRES_PASSWORD=supersecret -p 5432:5432 -d pgvector/pgvector:1.7` (choose any password you would like)
+3. Run PostgreSQL: `docker run --name bloom-db -e POSTGRES_PASSWORD=supersecret -p 5432:5432 -d pgvector/pgvector:pg17` (choose any password you would like)
 4. Copy the `.env.example` file to `.env` and fill in the necessary values. Be sure to set the password in the DATABASE_URL to the one you chose in step 3.
 5. Run `cargo run` to start the bot
 

--- a/src/commands/bookmark.rs
+++ b/src/commands/bookmark.rs
@@ -2,6 +2,7 @@ use crate::commands::helpers::common;
 use crate::commands::helpers::database::{self, MessageType};
 use crate::commands::helpers::pagination::{PageRowRef, PageType, Paginator};
 use crate::config::{EMOJI, ENTRIES_PER_PAGE};
+use crate::data::bookmark::Bookmark;
 use crate::database::DatabaseHandler;
 use crate::{Context, Data as AppData, Error as AppError};
 use anyhow::{Context as AnyhowContext, Result};
@@ -58,17 +59,9 @@ pub async fn add_bookmark(
   let bookmark_data = AddBookmarkModal::execute(ctx).await?;
 
   if let Some(bookmark) = bookmark_data {
-    let message_link = message.link();
-    let description = bookmark.description;
+    let new_bookmark = Bookmark::new(guild_id, user_id, message.link(), bookmark.description);
 
-    DatabaseHandler::add_bookmark(
-      &mut transaction,
-      &guild_id,
-      &user_id,
-      message_link.as_str(),
-      description.as_deref(),
-    )
-    .await?;
+    DatabaseHandler::add_bookmark(&mut transaction, &new_bookmark).await?;
 
     database::commit_and_say(
       poise::Context::Application(ctx),
@@ -163,14 +156,9 @@ async fn add(
     return Ok(());
   }
 
-  DatabaseHandler::add_bookmark(
-    &mut transaction,
-    &guild_id,
-    &user_id,
-    message.link().as_str(),
-    description.as_deref(),
-  )
-  .await?;
+  let new_bookmark = Bookmark::new(guild_id, user_id, message.link(), description);
+
+  DatabaseHandler::add_bookmark(&mut transaction, &new_bookmark).await?;
 
   database::commit_and_say(
     ctx,

--- a/src/data/bookmark.rs
+++ b/src/data/bookmark.rs
@@ -1,11 +1,36 @@
 use crate::commands::helpers::pagination::{PageRow, PageType};
+use crate::handlers::database::{CreatesInDatabase, DeletesInDatabase};
 use chrono::Utc;
+use sqlx::postgres::PgArguments;
+use sqlx::query::Query;
+use sqlx::Postgres;
+use ulid::Ulid;
 
 pub struct Bookmark {
   pub id: String,
+  guild_id: serenity::GuildId,
+  user_id: serenity::UserId,
   pub link: String,
   pub description: Option<String>,
-  pub added: chrono::DateTime<Utc>,
+  pub added: Some(chrono::DateTime<Utc>),
+}
+
+impl Bookmark {
+  pub(crate) fn new(
+    guild_id: serenity::GuildId,
+    user_id: serenity::UserId,
+    link: String,
+    description: Option<String>,
+  ) -> Self {
+    Self {
+      id: Ulid::new().to_string(),
+      guild_id,
+      user_id,
+      link,
+      description,
+      added: None,
+    }
+  }
 }
 
 impl PageRow for Bookmark {
@@ -30,5 +55,31 @@ impl PageRow for Bookmark {
         self.id,
       )
     }
+  }
+}
+
+impl CreatesInDatabase for Bookmark {
+  fn create_query(&self) -> Query<Postgres, PgArguments> {
+    sqlx::query!(
+      r#"
+        INSERT INTO bookmarks (record_id, user_id, guild_id, message_link, user_desc) VALUES ($1, $2, $3, $4, $5)
+      "#,
+      self.id,
+      self.user_id.to_string(),
+      self.guild_id.to_string(),
+      self.link,
+      self.description,
+    )
+  }
+}
+
+impl DeletesInDatabase for Bookmark {
+  fn delete_query(id: String) -> Query<Postgres, PgArguments> {
+    sqlx::query!(
+      r#"
+        DELETE FROM bookmarks WHERE record_id = $1
+      "#,
+      id,
+    )
   }
 }

--- a/src/handlers/database.rs
+++ b/src/handlers/database.rs
@@ -50,15 +50,15 @@ pub(crate) trait CreatesInDatabase {
   fn create_query(&self) -> Query<Postgres, PgArguments>;
 }
 
-pub(crate) trait UpdatesInDatabase {
-  fn update_query(&self) -> Query<Postgres, PgArguments>;
-}
-
 pub(crate) trait DeletesInDatabase {
-  fn delete_query(id: String) -> Query<Postgres, PgArguments>;
+  fn delete_query<'a>(id: String) -> Query<'a, Postgres, PgArguments>;
 }
 
 impl DatabaseHandler {
+  pub fn from_pool(pool: sqlx::PgPool) -> Self {
+    Self { pool }
+  }
+
   pub async fn new() -> Result<Self> {
     let database_url =
       std::env::var("DATABASE_URL").with_context(|| "Missing DATABASE_URL environment variable")?;
@@ -586,27 +586,18 @@ impl DatabaseHandler {
     guild_id: &serenity::GuildId,
     user_id: &serenity::UserId,
   ) -> Result<Vec<Bookmark>> {
-    let rows = sqlx::query!(
+    let bookmarks = sqlx::query_as!(
+      Bookmark,
       r#"
-        SELECT record_id, message_link, user_desc, occurred_at FROM bookmarks WHERE user_id = $1 AND guild_id = $2 ORDER BY occurred_at ASC
+        SELECT record_id AS id, guild_id, user_id, message_link AS link, user_desc AS description, occurred_at AS added FROM bookmarks WHERE guild_id = $1 AND user_id = $2 ORDER BY occurred_at ASC
       "#,
-      user_id.to_string(),
       guild_id.to_string(),
+      user_id.to_string(),
     )
     .fetch_all(&mut **transaction)
     .await?;
 
-    let bookmark_data = rows
-      .into_iter()
-      .map(|row| Bookmark {
-        id: row.record_id,
-        link: row.message_link,
-        description: row.user_desc,
-        added: row.occurred_at,
-      })
-      .collect();
-
-    Ok(bookmark_data)
+    Ok(bookmarks)
   }
 
   pub async fn search_bookmarks(
@@ -615,14 +606,14 @@ impl DatabaseHandler {
     user_id: &serenity::UserId,
     keyword: &str,
   ) -> Result<Vec<Bookmark>> {
-    let rows = sqlx::query!(
+    let bookmarks = sqlx::query_as!(
+      Bookmark,
       r#"
-        SELECT record_id, message_link, user_desc, occurred_at,
-        ts_rank(desc_tsv, websearch_to_tsquery('english', $3)) AS rank
+        SELECT record_id AS id, guild_id, user_id, message_link AS link, user_desc AS description, occurred_at AS added
         FROM bookmarks
         WHERE user_id = $1 AND guild_id = $2
         AND (desc_tsv @@ websearch_to_tsquery('english', $3))
-        ORDER BY rank DESC
+        ORDER BY ts_rank(desc_tsv, websearch_to_tsquery('english', $3)) DESC
       "#,
       user_id.to_string(),
       guild_id.to_string(),
@@ -631,17 +622,7 @@ impl DatabaseHandler {
     .fetch_all(&mut **transaction)
     .await?;
 
-    let bookmark_data = rows
-      .into_iter()
-      .map(|row| Bookmark {
-        id: row.record_id,
-        link: row.message_link,
-        description: row.user_desc,
-        added: row.occurred_at,
-      })
-      .collect();
-
-    Ok(bookmark_data)
+    Ok(bookmarks)
   }
 
   pub async fn remove_bookmark(
@@ -3194,7 +3175,7 @@ impl DatabaseHandler {
   }
 
   pub async fn insert_star_message(
-    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    transaction: &mut sqlx::Transaction<'_, Postgres>,
     starred_message_id: &serenity::MessageId,
     board_message_id: &serenity::MessageId,
     starred_channel_id: &serenity::ChannelId,
@@ -3211,6 +3192,110 @@ impl DatabaseHandler {
     )
     .execute(&mut **transaction)
     .await?;
+
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::data::bookmark::Bookmark;
+  use crate::handlers::database::DatabaseHandler;
+  use poise::serenity_prelude::{GuildId, UserId};
+  use sqlx::PgPool;
+
+  #[sqlx::test(fixtures(path = "fixtures", scripts("bookmarks")))]
+  async fn test_get_bookmarks(pool: PgPool) -> Result<(), anyhow::Error> {
+    let handler = DatabaseHandler { pool };
+    let mut transaction = handler.start_transaction().await?;
+    let bookmarks = DatabaseHandler::get_bookmarks(
+      &mut transaction,
+      &GuildId::new(123u64),
+      &UserId::new(123u64),
+    )
+    .await?;
+
+    assert_eq!(bookmarks.len(), 4);
+    assert_eq!(bookmarks[0].link, "https://foo.bar/1234");
+    assert_eq!(bookmarks[0].description, Some("A bar of foo".to_string()));
+    assert_eq!(bookmarks[0].id, "01JBPTWBXJNAKK288S3D89JK7G".to_string());
+    assert_eq!(
+      bookmarks[0].added,
+      chrono::DateTime::from_timestamp(1_704_067_200, 0)
+    );
+
+    assert_eq!(bookmarks[1].link, "https://foo.bar/1235");
+    assert_eq!(bookmarks[1].id, "01JBPTWBXJNAKK288S3D89JK7H".to_string());
+    assert_eq!(
+      bookmarks[1].added,
+      chrono::DateTime::from_timestamp(1_704_070_800, 0)
+    );
+
+    assert_eq!(bookmarks[2].description, None);
+
+    Ok(())
+  }
+
+  #[sqlx::test(fixtures(path = "fixtures", scripts("bookmarks")))]
+  async fn test_bookmark_count(pool: PgPool) -> Result<(), anyhow::Error> {
+    let handler = DatabaseHandler { pool };
+    let mut transaction = handler.start_transaction().await?;
+    let count = DatabaseHandler::get_bookmark_count(
+      &mut transaction,
+      &GuildId::new(123u64),
+      &UserId::new(123u64),
+    )
+    .await?;
+
+    assert_eq!(count, 4);
+
+    Ok(())
+  }
+
+  #[sqlx::test(fixtures(path = "fixtures", scripts("bookmarks")))]
+  async fn test_remove_bookmark(pool: PgPool) -> Result<(), anyhow::Error> {
+    let handler = DatabaseHandler { pool };
+    let mut transaction = handler.start_transaction().await?;
+    let count =
+      DatabaseHandler::remove_bookmark(&mut transaction, "01JBPTWBXJNAKK288S3D89JK7J").await?;
+
+    assert_eq!(count, 1);
+
+    let new_count = DatabaseHandler::get_bookmark_count(
+      &mut transaction,
+      &GuildId::new(123u64),
+      &UserId::new(123u64),
+    )
+    .await?;
+
+    assert_eq!(new_count, 3);
+
+    Ok(())
+  }
+
+  #[sqlx::test(fixtures(path = "fixtures", scripts("bookmarks")))]
+  async fn test_add_bookmark(pool: PgPool) -> Result<(), anyhow::Error> {
+    let handler = DatabaseHandler { pool };
+    let mut transaction = handler.start_transaction().await?;
+    () = DatabaseHandler::add_bookmark(
+      &mut transaction,
+      &Bookmark::new(
+        GuildId::new(123u64),
+        UserId::new(123u64),
+        "https://polyglot.engineer/".to_string(),
+        None,
+      ),
+    )
+    .await?;
+
+    let new_count = DatabaseHandler::get_bookmark_count(
+      &mut transaction,
+      &GuildId::new(123u64),
+      &UserId::new(123u64),
+    )
+    .await?;
+
+    assert_eq!(new_count, 5);
 
     Ok(())
   }

--- a/src/handlers/fixtures/bookmarks.sql
+++ b/src/handlers/fixtures/bookmarks.sql
@@ -1,0 +1,11 @@
+INSERT INTO bookmarks (record_id, user_id, guild_id, message_link, user_desc, occurred_at)
+VALUES
+    ('01JBPTWBXJNAKK288S3D89JK7G', '123', '123', 'https://foo.bar/1234', 'A bar of foo', CAST('2024-01-01 00:00:00+00' AS TIMESTAMPTZ)),
+    ('01JBPTWBXJNAKK288S3D89JK7H', '123', '123', 'https://foo.bar/1235', 'A baz of bat', CAST('2024-01-01 01:00:00+00' AS TIMESTAMPTZ)),
+    ('01JBPTWBXJNAKK288S3D89JK7I', '123', '123', 'https://foo.bar/1236', null, CAST('2024-01-01 02:00:00+00' AS TIMESTAMPTZ)),
+    ('01JBPTWBXJNAKK288S3D89JK7J', '123', '123', 'https://foo.bar/1237', 'A quu of quux', CAST('2024-01-01 03:00:00+00' AS TIMESTAMPTZ)),
+    ('01JBPTWBXJNAKK288S3D89JK7K', '124', '123', 'https://foo.bar/1238', 'A quick brown fox', CAST('2024-01-01 00:00:00+00' AS TIMESTAMPTZ)),
+    ('01JBPTWBXJNAKK288S3D89JK7L', '124', '123', 'https://foo.bar/1239', 'Jumping over the lazy dog', CAST('2024-01-01 00:00:00+00' AS TIMESTAMPTZ)),
+    ('01JBPV1XJNAKK288S3D89JK7M1', '125', '127', 'https://baz.bat/1240', 'This little piggy', CAST('2024-01-01 00:00:00+00' AS TIMESTAMPTZ)),
+    ('01JBPV1XJNAKK288S3D89JK7N2', '125', '127', 'https://baz.bat/1241', 'Pancakes > waffles', CAST('2024-01-01 00:00:00+00' AS TIMESTAMPTZ))
+;


### PR DESCRIPTION
This transforms the database operations for Bookmark create/delete to use the `Bookmark` itself instead of a bunch of arguments. It also adds traits to generate the query to the `Bookmark` itself, this way we can move the queries closer to the struct.

This is the way I wish to update the rest of the database types, so I wanted to implement Bookmark first, which is relatively simple.

Also worthwhile may be a trait for `ReadsOneFromDatabase`, `ReadsManyFromDatabase`, and `SearchesInDatabase` or similar.